### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ Example `sympack.config.local.js`:
 const config = {
   install: {
     scope: 'local',
-    paths: ['../my-app', '/absolute/path/to/project'],
+    projects: [
+      { path: '../my-app' },
+      { path: '/absolute/path/to/project' },
+      { path: '../project-with-peers', hasPeerDependencies: true }
+    ],
   },
 };
 
@@ -127,7 +131,11 @@ const config = {
 const config = {
   install: {
     scope: 'local',
-    paths: ['../frontend-app', '../backend-service', '../shared-components'],
+    projects: [
+      { path: '../frontend-app' },
+      { path: '../backend-service' },
+      { path: '../shared-components', hasPeerDependencies: true }
+    ],
   },
 };
 ```
@@ -147,8 +155,13 @@ const config = {
 
 - **scope**: `'global' | 'local'` - Installation scope
   - `'global'`: Install package globally using `npm install -g`
-  - `'local'`: Install package in specified local paths
-- **paths**: `string[]` - Array of absolute or relative paths for local installation
+  - `'local'`: Install package in specified local projects
+- **projects**: `ProjectConfig[]` - Array of project configurations for local installation
+
+#### `ProjectConfig`
+
+- **path**: `string` - Absolute or relative path to the project directory
+- **hasPeerDependencies**: `boolean` (optional) - Whether to use `--legacy-peer-deps` flag during installation (default: `false`)
 
 ### CLI Commands
 

--- a/public/files/sympack.config.local.js
+++ b/public/files/sympack.config.local.js
@@ -4,7 +4,7 @@
 const config = {
   install: {
     scope: 'local',
-    paths: undefined
+    projects: undefined
   }
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ import {
   CONFIG_LOCAL_FILE,
   CONFIG_VALUE_REGEX,
 } from './constants.js';
-import { SympackConfig } from './types.js';
+import { ProjectConfig, SympackConfig } from './types.js';
 
 const __dirname = import.meta.dirname;
 
@@ -117,8 +117,8 @@ export async function loadConfig(): Promise<SympackConfig> {
         `scope: '${scope}'`,
       );
       content = content.replace(
-        new RegExp(`paths: ${CONFIG_VALUE_REGEX.source}`),
-        `paths: [${paths.map((p) => `'${p}'`).join(', ')}]`,
+        new RegExp(`projects: ${CONFIG_VALUE_REGEX.source}`),
+        `projects: [${paths.map((p) => `{ path: '${p}' }`).join(', ')}]`,
       );
       await fs.writeFile(localConfigPath, content, 'utf-8');
       logger.succeed(`Created: ${chalk.green(CONFIG_LOCAL_FILE)}`);
@@ -154,7 +154,7 @@ export async function loadConfig(): Promise<SympackConfig> {
     merge(localConfig, {
       install: {
         scope,
-        paths,
+        projects: paths.map((p) => ({ path: p }) as ProjectConfig),
       },
     } as SympackConfig);
   }
@@ -193,7 +193,7 @@ export function validateConfig(config: SympackConfig): void {
 
   if (
     config.install.scope === 'local' &&
-    (!config.install.paths || config.install.paths.length === 0)
+    (!config.install.projects || config.install.projects.length === 0)
   ) {
     logger.fail(`Missing install.paths configuration in ${CONFIG_LOCAL_FILE}`);
     process.exit(1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,24 @@
 export type ScopeType = 'global' | 'local';
 export type SympackConfig = Partial<Config>;
 
+export interface ProjectConfig {
+  /**
+   * The path to the project where the package will be installed.
+   *
+   * This can be an absolute path or a path relative to the current working directory.
+   *
+   * @example '/path/to/project' or './relative/path/to/project'
+   */
+  path: string;
+  /**
+   * Indicates whether the project has peer dependencies that need to be resolved during installation.
+   * If set to true, the installation command will include the `--legacy-peer-deps` flag.
+   *
+   * @default false
+   */
+  hasPeerDependencies?: boolean;
+}
+
 interface Config {
   watch: {
     /**
@@ -24,10 +42,9 @@ interface Config {
      */
     scope: ScopeType;
     /**
-     * An array of absolute or relative paths where the package will be installed.
-     * @example ['/path/to/project1', '../path/to/project2']
+     * An array of project configurations where the package will be installed when `scope` is set to `local`.
      */
-    paths?: string[];
+    projects?: ProjectConfig[];
   };
 }
 
@@ -36,5 +53,5 @@ export interface PackageProps {
   name: string;
   version: string;
   scope: ScopeType;
-  paths?: string[];
+  projects?: ProjectConfig[];
 }


### PR DESCRIPTION
This pull request refactors the configuration and installation workflow for local projects, replacing the previous `paths` array with a more flexible `projects` array of objects. Each project can now specify additional metadata, such as whether to use the `--legacy-peer-deps` flag during installation. The changes impact the configuration schema, CLI argument handling, and installation logic, and update documentation and type definitions accordingly.

**Configuration and Type Refactor:**

- Replaced the `paths` array with a `projects` array in the configuration, allowing each project to be represented as an object with `path` and optional `hasPeerDependencies` properties (`ProjectConfig`). Updated all relevant type definitions and interfaces to reflect this change. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR4-R21) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL27-R47) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL39-R56) [[4]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L12-R12) [[5]](diffhunk://#diff-20da981bb437131fc964cf3ac8dbda479f1ef5a050f6e750dd518f8a3c533663L8-R24)

**Installation Logic and CLI Handling:**

- Updated the CLI and watcher logic to accept and parse `--project` arguments instead of `--paths`, supporting the new object-based project configuration and the optional `hasPeerDependencies` flag. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L23-R23) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L39-R55) [[3]](diffhunk://#diff-2207093beefcc6234a2205469f9b96ca2549952abdc72fb9390daf9ce4a20855L4-R30)
- Modified the installation process to use the `projects` array, passing the correct flags to `npm install` based on each project's configuration, including conditionally adding `--legacy-peer-deps`.

**Documentation Updates:**

- Updated `README.md` to document the new `projects` configuration, including examples and explanations of the `ProjectConfig` object and its `hasPeerDependencies` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-R138) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R164)

**Config File and Validation Adjustments:**

- Adjusted config file generation, loading, and validation to support the new `projects` array structure instead of `paths`. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L120-R121) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L157-R157) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L196-R196) [[4]](diffhunk://#diff-dd861c752e4bc08931d86f0a8d58510e128b86c93a4acc2ea6d1bd666bebddfeL7-R7)

**Miscellaneous Improvements:**

- Improved logging output for package creation and installation, and ensured consistent use of the new configuration structure throughout the codebase. [[1]](diffhunk://#diff-20da981bb437131fc964cf3ac8dbda479f1ef5a050f6e750dd518f8a3c533663L67-R68) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L94-R107)